### PR TITLE
Unsaved attributes are reset when a model is saved via 'create'.

### DIFF
--- a/backbone.trackit.js
+++ b/backbone.trackit.js
@@ -175,7 +175,7 @@
   Backbone.sync = _.wrap(Backbone.sync, function(oldSync, method, model, options) {
     options || (options = {});
 
-    if (method == 'update') {
+    if (method == 'update' || method == 'create') {
       options.success = _.wrap(options.success, _.bind(function(oldSuccess, data, textStatus, jqXHR) {
         var ret;
         if (oldSuccess) ret = oldSuccess.call(this, data, textStatus, jqXHR);


### PR DESCRIPTION
This is intended to resolve issue #2.
