### PR TITLE
unsavedChanges: pass a reference to the changed model

### DIFF
--- a/backbone.trackit.js
+++ b/backbone.trackit.js
@@ -136,7 +136,7 @@
     // supplying the result of whether there are unsaved
     // changes and a changed attributes hash.
     _triggerUnsavedChanges: function() {
-      this.trigger('unsavedChanges', !_.isEmpty(this._unsavedChanges), _.clone(this._unsavedChanges));
+      this.trigger('unsavedChanges', !_.isEmpty(this._unsavedChanges), _.clone(this._unsavedChanges), this);
       if (this.unsaved) updateUnsavedModels(this);
     }
   });


### PR DESCRIPTION
This will be useful for putting an unsavedChanges listener on a collection.
Without this I cannot associate the changed attributes with a
particular model.  I am interested in having access to the model's id so
that I can batch save many models at once.
