### PR TITLE
Removed hard coded string from prompt, for internationalization purposes...

### DIFF
--- a/backbone.trackit.js
+++ b/backbone.trackit.js
@@ -44,7 +44,7 @@
   Backbone.History.prototype.navigate = _.wrap(Backbone.History.prototype.navigate, function(oldNav, fragment, options) {
     var prompt = getPrompt('unloadRouterPrompt', fragment, options);
     if (prompt) {
-      if (confirm(prompt + ' \n\nAre you sure you want to leave this page?')) {
+      if (confirm(prompt)) {
         oldNav.call(this, fragment, options);
       }
     } else {


### PR DESCRIPTION
Hey! Just removed the hard coded message when prompting from `unloadRouterPrompt` option. Better for internationalization. ;)
