### PR TITLE
Using model.set to replace attributes

### DIFF
--- a/backbone.trackit.js
+++ b/backbone.trackit.js
@@ -105,7 +105,7 @@
     // started, the last save, or last restart.
     resetAttributes: function() {
       if (!this._trackingChanges) return;
-      this.attributes = this._originalAttrs;
+      this.set(this._originalAttrs);
       this._resetTracking();
       this._triggerUnsavedChanges();
       return this;


### PR DESCRIPTION
Model.set() will trigger built in backbone events, but simply replacing the attributes hash will not.
- works very well with stickit

-Added new line as well
