### PR TITLE
Reset tracking before calling callback on model in save method

### DIFF
--- a/backbone.trackit.js
+++ b/backbone.trackit.js
@@ -180,6 +180,8 @@
     options || (options = {});
 
     if (method == 'update' || method == 'create' || method == 'patch') {
+      //don't track attributes which will be returned by server during sync
+      options.trackit_silent = true;
       options.success = _.wrap(options.success, _.bind(function(oldSuccess, data, textStatus, jqXHR) {
         var ret;
         //reset tracking before calling old callback


### PR DESCRIPTION
Model tracking should be reset before calling old `success` callback during save method. For now, this example from documentation doesn't work: 

``` javascript
model.save({}, {
    success: function() {
        console.log(model.unsavedAttributes());  // >> false
    }
});
```

because we call success and then reset tracking. This PR solve this problem.

Thanks.
