### PR TITLE
avoid using _.each on set method

### DIFF
--- a/backbone.trackit.js
+++ b/backbone.trackit.js
@@ -159,12 +159,13 @@
     ret = oldSet.call(this, attrs, options);
 
     if (this._trackingChanges && !options.silent && !options.trackit_silent) {
-      _.each(attrs, _.bind(function(val, key) {
-        if (_.isEqual(this._originalAttrs[key], val))
-          delete this._unsavedChanges[key];
-        else
-          this._unsavedChanges[key] = val;
-      }, this));
+        for (key in attrs) {
+            val = attrs[key];
+            if (_.isEqual(this._originalAttrs[key], val))
+                delete this._unsavedChanges[key];
+            else
+                this._unsavedChanges[key] = val;
+        }
       this._triggerUnsavedChanges();
     }
     return ret;


### PR DESCRIPTION
Models with an attribute named 'length' will make this each work as an array.

From underscore docs

> Note: Collection functions work on arrays, objects, and array-like objects such as arguments, NodeList and similar. **But it works by duck-typing, so avoid passing objects with a numeric length property**. It's also good to note that an each loop cannot be broken out of — to break, use _.find instead.

---

I do not check for `hasOwnProperty` in the `for` statement in the new code because it's not done in `Backbone` either so, just to keep things the same.

**Explanation:**

We have been using `trackit` for a while with [Directus](https://github.com/directus/directus). We used to have a weird bug that we weren't able to reproduce, after a long research and testing we find out the problem was `_.each`, we have models that represents columns, a column can have a `length` but when we use columns with small length number 10, 100, 255, this wasn't noticeable, then we started using `MEDIUMTEXT` and `LONGTEXT` which translate to a `16,777,215` and `4,294,967,295` which takes time to process an array of that length, blocking the page from a couple of seconds to minutes.

